### PR TITLE
Fix eventlog.rb for ruby 1.9

### DIFF
--- a/test/test_eventlog.rb
+++ b/test/test_eventlog.rb
@@ -130,6 +130,14 @@ class TC_Win32_EventLog < Test::Unit::TestCase
     }
   end
   
+  test "two reads return the same descriptions" do
+      read_one = EventLog.read
+      read_two = EventLog.read
+      read_one.size.times do |i|
+          assert_equal(read_one[i], read_two[i])
+      end
+  end
+
   # I've added explicit breaks because an event log could be rather large.
   # 
   test "singleton read method does not require any arguments" do


### PR DESCRIPTION
This is a fix for reading the event log on ruby 1.9. [1] "rake test" now has only one failure on my ruby 1.9.2/win7 system. It doesn't look related to me, but if it is caused by my changes let me know and I'll look into it.

  1) Failure:
test_open_is_a_singleton_alias_for_new(TC_Win32_EventLog) [test/test_eventlog.rb:52]:
<#<Method: Class#new>> is alias of
<#<Method: Win32::EventLog.new>> expected

1: See the bug on rubyforge: http://rubyforge.org/tracker/index.php?func=detail&aid=28904&group_id=85&atid=411
