### PR TITLE
Rescue LoadError when wevtapi.dll can't be loaded

### DIFF
--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -42,10 +42,14 @@ module Windows
     attach_function :Wow64DisableWow64FsRedirection, [:pointer], :bool
     attach_function :Wow64RevertWow64FsRedirection, [:ulong], :bool
 
-    ffi_lib :wevtapi
+    begin
+      ffi_lib :wevtapi
 
-    attach_function :EvtClose, [:handle], :bool
-    attach_function :EvtOpenPublisherMetadata, [:handle, :buffer_in, :buffer_in, :dword, :dword], :handle
-    attach_function :EvtGetPublisherMetadataProperty, [:handle, :int, :dword, :dword, :pointer, :pointer], :bool
+      attach_function :EvtClose, [:handle], :bool
+      attach_function :EvtOpenPublisherMetadata, [:handle, :buffer_in, :buffer_in, :dword, :dword], :handle
+      attach_function :EvtGetPublisherMetadataProperty, [:handle, :int, :dword, :dword, :pointer, :pointer], :bool
+    rescue LoadError
+      # 2003
+    end
   end
 end


### PR DESCRIPTION
The newer event logging APIs are not available prior to 2008 and Vista. As
a result, the following would fail on 2003:

```
C:\> ruby -e "require 'win32/eventlog'"
LoadError: can't convert Symbol into String.
Could not open library 'wevtapi.dll': The specified module could not be found.
```

This commit rescues the LoadError so that the gem can continue to be loaded on
older systems.
