### PR TITLE
Wrapped Wow64* in begin..rescue.

### DIFF
--- a/lib/win32/windows/functions.rb
+++ b/lib/win32/windows/functions.rb
@@ -39,8 +39,17 @@ module Windows
     attach_function :FreeLibrary, [:handle], :bool
     attach_function :LoadLibraryEx, :LoadLibraryExA, [:string, :handle, :dword], :handle
     attach_function :WaitForSingleObject, [:handle, :dword], :dword
-    attach_function :Wow64DisableWow64FsRedirection, [:pointer], :bool
-    attach_function :Wow64RevertWow64FsRedirection, [:ulong], :bool
+
+    begin
+      attach_function :Wow64DisableWow64FsRedirection, [:pointer], :bool
+      attach_function :Wow64RevertWow64FsRedirection, [:ulong], :bool
+    rescue LoadError
+      # XP 32
+      def Wow64DisableWow64FsRedirection(oldValue)
+      end
+      def Wow64RevertWow64FsRedirection(oldValue)
+      end
+    end
 
     begin
       ffi_lib :wevtapi


### PR DESCRIPTION
These functions don't seem to exist on Windows XP 32 bit, rendering support for it, which was broken since at least 0.6.1, probably since 0.6.0.

It shouldn't affect Windows versions where those functions exist.
And those where they don't exist would not work with 0.6.0-0.6.2 anyway :)
